### PR TITLE
[DO NOT MERGE YET] Enable usage with hyphens in hostname

### DIFF
--- a/run-varnish.sh
+++ b/run-varnish.sh
@@ -42,7 +42,7 @@ do
         continue
     fi
 
-    if [[ "${!var}" =~ ([a-zA-Z0-9]+):?([0-9]+)? ]]; then
+    if [[ "${!var}" =~ ([a-zA-Z0-9-]+):?([0-9]+)? ]]; then
         host="${BASH_REMATCH[1]}"
         port="${BASH_REMATCH[2]}"
     fi


### PR DESCRIPTION
I'm trying out the deployment of the containerized Mediawiki install project on Kubernetes instead of Docker Swarm (see https://github.com/opensdcp/opensdcp-infrastructure and https://github.com/opensdcp/opensdcp-wiki) and since the services usually use names like `opensdcp-wiki-yourservicename` the Regex checks fail currently (it's just `opensdcp` which then does not resolve into a hostname). This is probably not ready yet (I need to test more).